### PR TITLE
support for multiple java processes and process auto-discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,32 @@ Beats for Java HotSpot VM. This beat ships all performance counters in HotSpot V
 
 ## Features
 
-* HSBeat collects periodically all raw performance counter values in Java HotSpot VM. 
+* HSBeat collects periodically all raw performance counter values in Java HotSpot VM.
   * Constant values are shipped only once (first time) to Elasticsearch.
   * Monotonic and Variable values are shipped in all collection time.
-* If you want to calculate these values (e.g. ratio, time), you have to implement it in your client apps. 
+* If you want to calculate these values (e.g. ratio, time), you have to implement it in your client apps.
   * HSBeat Kibana dashboard sample use dynamic scripting on Elasticsearch.
+* Collects values for multiple Java processes or for a given PID
+  * When a PID is not given, it collects counter values from all running Java processes that create a hsperfdata file under <tmp>/hsperfdata_*
 
 
 ## Getting started
 
+### Collecting counters from a single Java process
 ```
 $ go get github.com/YaSuenag/hsbeat
 $ hsbeat -E hsbeat.modules.0.pid=<PID>
 ```
 
-If you want to use sample dashboard, you can import as below:
+### Collecting counters from all running Java processes
+```
+$ go get github.com/YaSuenag/hsbeat
+$ hsbeat
+```
+
+Note: only process for which the user running hsbeat has read access to <tmp>/hsperfdata_*/<pid> are monitored
+
+### If you want to use sample dashboard, you can import as below:
 
 ```
 $ import_dashboards --dir $GOPATH/src/github.com/YaSuenag/hsbeat/etc/kibana
@@ -31,4 +42,3 @@ $ import_dashboards --dir $GOPATH/src/github.com/YaSuenag/hsbeat/etc/kibana
 ```
 script.engine.groovy.inline: true
 ```
-

--- a/utils/multierror/multierror_test.go
+++ b/utils/multierror/multierror_test.go
@@ -1,0 +1,79 @@
+package multierror
+
+import (
+  "testing"
+  "errors"
+  "io"
+)
+
+func TestHasErrors(t *testing.T) {
+  e := new(MultiError)
+  assertFalse(t, e.HasErrors())
+  e.Append(errors.New("first error"))
+  assertTrue(t, e.HasErrors())
+}
+
+func TestCount(t *testing.T) {
+  e := new(MultiError)
+  assertEquals(t, 0, e.Count())
+  e.Append(errors.New("first error"))
+  assertEquals(t, 1, e.Count())
+  e.Append(errors.New("second error"))
+  assertEquals(t, 2, e.Count())
+
+}
+
+func TestAppend(t *testing.T) {
+  e := new(MultiError)
+  assertFalse(t, e.HasErrors())
+  e.Append(errors.New("first error"))
+  assertTrue(t, e.HasErrors())
+  e.Append(errors.New("second error"))
+  assertEquals(t, 2, e.Count())
+  e.Append(io.EOF) // test with some standard error
+  assertEquals(t, 3, e.Count())
+}
+
+func TestDontAppendNil(t *testing.T) {
+  e := new(MultiError)
+  assertFalse(t, e.HasErrors())
+  e.Append(errors.New("first error"))
+  assertEquals(t, 1, e.Count())
+  e.Append(nil)
+  assertEquals(t, 1, e.Count())
+  e.Append(errors.New("second actual error"))
+  assertEquals(t, 2, e.Count())
+
+}
+
+func TestError(t *testing.T) {
+  e := new(MultiError)
+  e.Append(errors.New("first error"))
+  e.Append(errors.New("second error"))
+  assertEquals(t, "multiple errors:\nfirst error\nsecond error", e.Error())
+}
+
+func TestStringer(t *testing.T) {
+  e := new(MultiError)
+  e.Append(errors.New("first error"))
+  e.Append(errors.New("second error"))
+  assertEquals(t, "multiple errors:\nfirst error\nsecond error", e.String())
+}
+
+func assertEquals(t *testing.T, expected interface{}, actual interface{}) {
+  if expected != actual {
+    t.Errorf("%v is not equal to %v", expected, actual)
+  }
+}
+
+func assertTrue(t *testing.T, actual bool) {
+  if ! actual {
+    t.Errorf("expected true got false")
+  }
+}
+
+func assertFalse(t *testing.T, actual bool) {
+  if actual {
+    t.Errorf("expected false got true")
+  }
+}

--- a/utils/multierror/mutilerror.go
+++ b/utils/multierror/mutilerror.go
@@ -1,0 +1,44 @@
+package multierror
+
+type MultiError struct {
+	errors []error
+}
+
+
+func (e *MultiError) Error() string {
+	return e.format()
+}
+
+func (e *MultiError) String() string {
+	return e.format()
+}
+
+func (e *MultiError) Append(err error) {
+	if err != nil {
+		e.errors = append(e.errors, err)
+	}
+}
+
+func (e *MultiError) HasErrors() bool {
+	return len(e.errors) > 0
+}
+
+func (e *MultiError) Count() int {
+  return len(e.errors)
+}
+
+func (e *MultiError) format() string {
+	if len(e.errors) == 0 {
+		return "No errors"
+	}
+
+	if len(e.errors) == 1 {
+		return e.errors[0].Error()
+	}
+
+	msg := "multiple errors:"
+	for _, err := range e.errors {
+		msg += "\n" + err.Error()
+	}
+	return msg
+}


### PR DESCRIPTION
Hello,

I came across your project and I found it very useful, it addresses JVM metric collection, something missing in the standard beats.

In my use case, I don't know the PID of the process I need to monitor in advance since the process can be restarted at any time. I wanted to avoid restarting hsbeat every time the Java process was restarted so I decided to implement a new feature in hsbeat.

This pull request enhances HSbeat adding the possibility to collect metrics from multiple java processes without having to specify their PIDs.

Here is a short description of how it works.

  - If pid is configured as 0 or not configured (default is 0), running Java processes are auto-discovered at each Fetch interval
  - Fetch returns a list of events instead of a single event, one event per running java process
  - Processes are discovered by looking under the <temp>/hsperfdata_* directories, typically one file per running java process exists
  - A map of running java processes is stored inside MetricSet, the map is initialized as empty and updated (add or remove) at each Fetch interval
  - hsperfdata file path is not tied to the user running hsbeat so that if run as root it can collect data from Java processes ran by any user (assuming all users have the same <temp> directory)

Further improvements

  - Accept a list of PIDs and monitor only those
  - Accept a list of regexps and monitor only Java process whose sun/rt/javaCommand entry matches any of the configured regexes

Hope you like this enhancement and accept the pull request. 

I'm new to golang and fairly new to ELK, any feedback is more than welcome.

Thanks for implementing hsbeat!

Fernando